### PR TITLE
Remove GitHub Token from Build Display. Fixes issue #17

### DIFF
--- a/.build/tasks/New-Release.GitHub.build.ps1
+++ b/.build/tasks/New-Release.GitHub.build.ps1
@@ -110,7 +110,7 @@ task Publish_release_to_GitHub -if ($GitHubToken -and (Get-Module -Name PowerShe
         }
 
         $displayGHReleaseParams = $getGHReleaseParams.Clone()
-        $displayGHReleaseParams.Remove('AccessToken')
+        $displayGHReleaseParams.['AccessToken'] = 'Redacted'
 
         Write-Build DarkGray "Checking if the Release exists: `r`n Get-GithubRelease $($displayGHReleaseParams | Out-String)"
 

--- a/.build/tasks/New-Release.GitHub.build.ps1
+++ b/.build/tasks/New-Release.GitHub.build.ps1
@@ -110,7 +110,7 @@ task Publish_release_to_GitHub -if ($GitHubToken -and (Get-Module -Name PowerShe
         }
 
         $displayGHReleaseParams = $getGHReleaseParams.Clone()
-        $displayGHReleaseParams.['AccessToken'] = 'Redacted'
+        $displayGHReleaseParams['AccessToken'] = 'Redacted'
 
         Write-Build DarkGray "Checking if the Release exists: `r`n Get-GithubRelease $($displayGHReleaseParams | Out-String)"
 

--- a/.build/tasks/New-Release.GitHub.build.ps1
+++ b/.build/tasks/New-Release.GitHub.build.ps1
@@ -109,7 +109,10 @@ task Publish_release_to_GitHub -if ($GitHubToken -and (Get-Module -Name PowerShe
             ErrorAction    = 'Stop'
         }
 
-        Write-Build DarkGray "Checking if the Release exists: `r`n Get-GithubRelease $($getGHReleaseParams | Out-String)"
+        $displayGHReleaseParams = $getGHReleaseParams.Clone()
+        $displayGHReleaseParams.Remove('AccessToken')
+
+        Write-Build DarkGray "Checking if the Release exists: `r`n Get-GithubRelease $($displayGHReleaseParams | Out-String)"
 
         try
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added logo.
 - Added Get-GHOwnerRepoFromRemoteUrl function.
 
+### Removed
+
+- Removed GitHub Access Token from variable being displayed during build. Fixes Issue #17.
+
 ### Changed
 
 - Fixed tasks to use the new Sampler version and its public functions.


### PR DESCRIPTION
# Pull Request

### Pull Request (PR) description

Removes GitHub Access Token from variable displayed during build.

#### This Pull Request (PR) fixes the following issues

- Fixes #17

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [ ] Integration tests added/updated (where possible).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).