### PR TITLE
don't fail on unavailble module nupkg (for when publishing release with assets in build.yml)

### DIFF
--- a/.build/tasks/New-Release.GitHub.build.ps1
+++ b/.build/tasks/New-Release.GitHub.build.ps1
@@ -1,6 +1,5 @@
-param (
-    # Base directory of all output (default to 'output')
-
+param
+(
     [Parameter()]
     [System.String]
     $BuiltModuleSubdirectory = (property BuiltModuleSubdirectory ''),
@@ -11,11 +10,11 @@ param (
 
     [Parameter()]
     [System.String]
-    $ProjectName = (property ProjectName $(Get-SamplerProjectName -BuildRoot $BuildRoot)),
+    $ProjectName = (property ProjectName ''),
 
     [Parameter()]
     [System.String]
-    $SourcePath = (property SourcePath $(Get-SamplerSourcePath -BuildRoot $BuildRoot)),
+    $SourcePath = (property SourcePath ''),
 
     [Parameter()]
     $ChangelogPath = (property ChangelogPath 'CHANGELOG.md'),
@@ -29,7 +28,7 @@ param (
 
     [Parameter()]
     [string]
-    $ReleaseBranch = (property ReleaseBranch 'master'),
+    $ReleaseBranch = (property ReleaseBranch 'main'),
 
     [Parameter()]
     [string]
@@ -49,7 +48,7 @@ param (
     $SkipPublish = (property SkipPublish ''),
 
     [Parameter()]
-    $MainGitBranch = (property MainGitBranch 'master')
+    $MainGitBranch = (property MainGitBranch 'main')
 )
 
 task Publish_release_to_GitHub -if ($GitHubToken -and (Get-Module -Name PowerShellForGitHub -ListAvailable)) {

--- a/.build/tasks/New-Release.GitHub.build.ps1
+++ b/.build/tasks/New-Release.GitHub.build.ps1
@@ -55,7 +55,6 @@ task Publish_release_to_GitHub -if ($GitHubToken -and (Get-Module -Name PowerShe
 
     . Set-SamplerTaskVariable
 
-
     $ReleaseNotesPath = Get-SamplerAbsolutePath -Path $ReleaseNotesPath -RelativeTo $OutputDirectory
     "`tRelease Notes Path            = '$ReleaseNotesPath'"
 
@@ -73,12 +72,6 @@ task Publish_release_to_GitHub -if ($GitHubToken -and (Get-Module -Name PowerShe
 
     Write-Build DarkGray "About to release '$PackageToRelease' with tag and release name '$ReleaseTag'"
     $remoteURL = git remote get-url origin
-
-    if ($remoteURL -notMatch 'github')
-    {
-        Write-Build Yellow "Skipping Publish to GitHub release at '$RemoteURL' (not a GitHub URL)."
-        return
-    }
 
     # Retrieving ReleaseNotes or defaulting to Updated ChangeLog
     if (Import-Module ChangelogManagement -ErrorAction SilentlyContinue -PassThru)
@@ -111,7 +104,10 @@ task Publish_release_to_GitHub -if ($GitHubToken -and (Get-Module -Name PowerShe
             ErrorAction    = 'Stop'
         }
 
-        Write-Build DarkGray "Checking if the Release exists: `r`n Get-GithubRelease $($getGHReleaseParams | Out-String)"
+        $displayGHReleaseParams = $getGHReleaseParams.Clone()
+        $displayGHReleaseParams['AccessToken'] = 'Redacted'
+
+        Write-Build DarkGray "Checking if the Release exists: `r`n Get-GithubRelease $($displayGHReleaseParams | Out-String)"
 
         try
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed Erroring when "$ProjectName.$ModuleVersion.nupkg" is not available (i.e. when using asset list in `Build.yaml`).
 - Fixed tasks to use the new Sampler version and its public functions.
 - Fixed RootModule not loaded because of Module Manifest.
 - Making this project use the prerelease version of Sampler for testing.


### PR DESCRIPTION
This is to enable the scenario where we don't produce a PowerShell module,
but for instance Chocolatey Package(s), that can be different from the Project Name.

Say you have several Choco packages in a repo, or you have several Azure Policy Guest Configuration Packages, you'd add the list of assets you want to publish in GitHub by listing them in the Build.Yaml (with a * for the version).
```yaml
####################################################
#               GitHub Configuration               #
####################################################
GitHubConfig:
  ReleaseAssets:
    - 'output/CHANGELOG.md'
    - 'output/MyPackage1*.nupkg
    - 'output/MyPackage2*.nupkg
  GitHubFilesToAdd:
    - 'CHANGELOG.md'
  GitHubConfigUserName: blah
  GitHubConfigUserEmail: blah@foobar.com
  UpdateChangelogOnPrerelease: false
```