### PR TITLE
Fix issue #22

### DIFF
--- a/.build/tasks/New-Release.GitHub.build.ps1
+++ b/.build/tasks/New-Release.GitHub.build.ps1
@@ -93,8 +93,7 @@ task Publish_release_to_GitHub -if ($GitHubToken -and (Get-Module -Name PowerShe
 
     if (!$SkipPublish)
     {
-        Write-Build DarkGray "Publishing GitHub release:"
-        Write-Build DarkGray ($releaseParams | Out-String)
+        Write-Build DarkGray ("About to publish a GitHub release for release tag '{0}'." -f $ReleaseTag)
 
         $getGHReleaseParams = @{
             Tag            = $ReleaseTag
@@ -105,9 +104,9 @@ task Publish_release_to_GitHub -if ($GitHubToken -and (Get-Module -Name PowerShe
         }
 
         $displayGHReleaseParams = $getGHReleaseParams.Clone()
-        $displayGHReleaseParams['AccessToken'] = 'Redacted'
+        $displayGHReleaseParams['AccessToken'] = '<Redacted>'
 
-        Write-Build DarkGray "Checking if the Release exists: `r`n Get-GithubRelease $($displayGHReleaseParams | Out-String)"
+        Write-Build DarkGray "Checking if the Release exists. Calling Get-GithubRelease with the parameters:`r`n$($displayGHReleaseParams | Out-String)"
 
         try
         {
@@ -129,10 +128,10 @@ task Publish_release_to_GitHub -if ($GitHubToken -and (Get-Module -Name PowerShe
                 Prerelease     = [bool]($PreReleaseTag)
                 Body           = $ReleaseNotes
                 AccessToken    = $GitHubToken
-                Verbose        = $true
+                Verbose        = $VerbosePreference
             }
 
-            Write-Build DarkGray "Creating new GitHub release '$ReleaseTag ' at '$remoteURL'."
+            Write-Build DarkGray "Creating new GitHub release '$ReleaseTag' at '$remoteURL'."
             $APIResponse = New-GitHubRelease @releaseParams
             Write-Build Green "Release Created. Adding Assets..."
             if ((-not [string]::IsNullOrEmpty($PackageToRelease)) -and (Test-Path -Path $PackageToRelease))

--- a/.build/tasks/New-Release.GitHub.build.ps1
+++ b/.build/tasks/New-Release.GitHub.build.ps1
@@ -93,7 +93,7 @@ task Publish_release_to_GitHub -if ($GitHubToken -and (Get-Module -Name PowerShe
 
     if (!$SkipPublish)
     {
-        Write-Build DarkGray ("About to publish a GitHub release for release tag '{0}'." -f $ReleaseTag)
+        Write-Build DarkGray "About to publish a GitHub release for release tag '$ReleaseTag'."
 
         $getGHReleaseParams = @{
             Tag            = $ReleaseTag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the Readme with the icon.
 - Adding delay after creating release to make sure the tag is available at next git pull.
 - Updating when to skip the Create Changelog PR task (adding -ListAvailable).
+- Task `Publish_release_to_GitHub`
+  - Removed unnecessary code line ([issue #22](https://github.com/gaelcolas/Sampler.GitHubTasks/issues/22)).
+  - Now the command `New-GitHubRelease` only outputs verbose information
+    if `$VerbosePreference` says so.
 
 ### Fixed
 


### PR DESCRIPTION
- Task `Publish_release_to_GitHub`
  - Removed unnecessary code line ([issue #22](https://github.com/gaelcolas/Sampler.GitHubTasks/issues/22)).
  - Now the command `New-GitHubRelease` only outputs verbose information
    if `$VerbosePreference` says so.

Fixes #22 